### PR TITLE
add script for db insert solve

### DIFF
--- a/script/db_insert_solve.rb
+++ b/script/db_insert_solve.rb
@@ -1,0 +1,64 @@
+require_relative '../config/environment'
+require_relative '../config/application'
+
+require 'benchmark'
+
+Rails.application.load_tasks
+
+def before_attach
+    Rake::Task['db:reset'].reenable
+    Rake::Task['db:reset'].invoke
+end
+
+dummy_path = Rails.root.join('test/fixtures/files', 'dummy.png')
+
+def attach_in_batches(dummy_path, num: 2, total: 1000, batch_size: 200)
+    times = 0
+    1..num.times do |n|
+        post = Post.create!(title: "Batch #{n + 1}", content: "Attaching images in batches")
+        temp = Benchmark.realtime do
+            (0...total).each_slice(batch_size) do |batch|
+                files = batch.map { |i| { io: File.open(dummy_path), filename: "image_#{i}.png", content_type: 'image/png' } }
+                post.images.attach(files)
+            end
+        end
+        puts "Batch #{n + 1} - Attached #{total} images in batches of #{batch_size} - Time taken: #{temp.round(2)}s"
+        times += temp
+    end
+    puts "Sum of all batches: #{times.round(2)}s"
+end
+
+def two_instance_attach_fast(dummy_path, num: 2, total: 1000)
+    times = 0
+    1..num.times do |n|
+        post = Post.create!(title: "Fast attach #{n + 1}", content: "Attaching images without reload")
+        temp = Benchmark.realtime do
+            blobs = total.times.map do |i|
+                ActiveStorage::Blob.create_and_upload!(
+                    io: File.open(dummy_path),
+                    filename: "image_#{i}.png",
+                    content_type: 'image/png',
+                    identify: false
+                )
+            end 
+            now = Time.current
+            attachments = blobs.map do |blob|
+                {
+                    name: "images",
+                    record_type: "Post",
+                    record_id: post.id,
+                    blob_id: blob.id,
+                    created_at: now
+                }
+            end
+            ActiveStorage::Attachment.insert_all!(attachments)
+        end
+        puts "Fast attach #{n + 1} - Attached 500 images using insert_all! - Time taken: #{temp.round(2)}s"
+        times += temp
+    end
+    puts "Sum of all fast attaches: #{times.round(2)}s"
+end
+
+before_attach
+attach_in_batches(dummy_path)
+two_instance_attach_fast(dummy_path)

--- a/script/db_insert_solve.rb
+++ b/script/db_insert_solve.rb
@@ -28,7 +28,7 @@ def attach_in_batches(dummy_path, num: 2, total: 1000, batch_size: 200)
     puts "Sum of all batches: #{times.round(2)}s"
 end
 
-def two_instance_attach_fast(dummy_path, num: 2, total: 1000)
+def attach_insert_all(dummy_path, num: 2, total: 1000)
     times = 0
     1..num.times do |n|
         post = Post.create!(title: "Fast attach #{n + 1}", content: "Attaching images without reload")
@@ -61,4 +61,4 @@ end
 
 before_attach
 attach_in_batches(dummy_path)
-two_instance_attach_fast(dummy_path)
+attach_insert_all(dummy_path)

--- a/script/n_1_queries.rb
+++ b/script/n_1_queries.rb
@@ -1,0 +1,56 @@
+# How to run this script:
+#
+# 1. Ensure you have set up the Rails environment and the required database.
+# 2. Place a dummy image file named 'dummy.png' in the 'test/fixtures/files' directory of your Rails project.
+# 3. Run this script using the following command from your Rails project root:
+#     bin/rails runner script/n_1_queries.rb
+#
+# The script will:
+# - Reset the database and create a sample Post.
+# - Attach 500 images to the Post, first one by one, then in batches of 50.
+# - Measure and print the time taken for each method, and compare their performance.
+require_relative '../config/environment'
+require_relative '../config/application'
+
+require 'benchmark'
+
+Rails.application.load_tasks
+
+def before_attach
+    Rake::Task['db:reset'].reenable
+    Rake::Task['db:reset'].invoke
+    Post.first_or_create!(title: "Test", content: "Test")
+end
+
+dummy_path = Rails.root.join('test/fixtures/files', 'dummy.png')
+
+def attach_one_by_one(dummy_path, total: 500)
+    post = before_attach
+    Benchmark.realtime do
+        total.times do |i|
+            post.images.attach(io: File.open(dummy_path), filename: "image_#{i}.png", content_type: 'image/png')
+        end
+    end
+end
+
+def attach_in_batches(dummy_path, total: 500, batch_size: 50)
+    post = before_attach
+    Benchmark.realtime do
+        (0...total).each_slice(batch_size) do |batch|
+            files = batch.map { |i| { io: File.open(dummy_path), filename: "image_#{i}.png", content_type: 'image/png' } }
+            post.images.attach(files)
+        end
+    end
+end
+
+time_one_by_one = attach_one_by_one(dummy_path)
+puts "Attach one by one: #{time_one_by_one.round(2)}s"
+
+time_in_batches = attach_in_batches(dummy_path)
+puts "Attach in batches: #{time_in_batches.round(2)}s"
+
+if time_one_by_one > time_in_batches
+    puts "Batch attaching is faster by #{(time_one_by_one - time_in_batches).round(2)}s"
+else
+    puts "Attaching one by one is faster by #{(time_in_batches - time_one_by_one).round(2)}s"
+end


### PR DESCRIPTION
# PR: Optimize ActiveStorage Attachments – Bypass N+1 and Heavy Join Queries

## Description

This PR introduces an optimized approach for attaching multiple images using **Rails Active Storage**, by **bypassing ActiveRecord joins**

The implementation is located in: 'script/db_insert_solve.rb'


Instead of using `.attach(...)`, which performs costly `JOIN` operations between `active_storage_attachments` and `active_storage_blobs`, this script demonstrates how to:

- Use **direct database inserts** (`insert_all!`) to bulk-insert attachment records.
- Avoid unnecessary `JOIN` queries on large datasets.
- Improve performance significantly when dealing with thousands of attachments.


##  Methods

- `attach_by_chunks`
→ Splits images into array chunks and attaches them in batches to minimize query overhead.

- `attach_insert_all`  
  → Uses `insert_all!` to insert attachments in bulk without triggering joins or reloads.


## Usage

Run the script with:

```bash
bin/rails runner script/db_insert_solve.rb
```


